### PR TITLE
Overwriting symlinks if they already exist

### DIFF
--- a/package/docker/openmrs/bahmni_startup.sh
+++ b/package/docker/openmrs/bahmni_startup.sh
@@ -17,12 +17,12 @@ envsubst < /etc/bahmni-emr/templates/bahmnicore.properties.template > /usr/local
 java $CHANGE_LOG_TABLE -jar $LIQUIBASE_JAR --driver=$DRIVER --url=$URL --username=$DB_USERNAME --password=$DB_PASSWORD --classpath=/etc/bahmni-lab-connect/atomfeed-client.jar:/usr/local/tomcat/webapps/openmrs.war --changeLogFile=sql/db_migrations.xml update
 
 # Setting Soft Links from bahmni_config (Moved from bahmni-web postinstall)
-ln -s /etc/bahmni_config/openmrs/obscalculator /usr/local/tomcat/.OpenMRS/obscalculator
-ln -s /etc/bahmni_config/openmrs/ordertemplates /usr/local/tomcat/.OpenMRS/ordertemplates
-ln -s /etc/bahmni_config/openmrs/encounterModifier /usr/local/tomcat/.OpenMRS/encounterModifier
-ln -s /etc/bahmni_config/openmrs/patientMatchingAlgorithm /usr/local/tomcat/.OpenMRS/patientMatchingAlgorithm
-ln -s /etc/bahmni_config/openmrs/elisFeedInterceptor /usr/local/tomcat/.OpenMRS/elisFeedInterceptor
-ln -s /etc/bahmni_config /usr/local/tomcat/.OpenMRS/bahmni_config
+ln -sf /etc/bahmni_config/openmrs/obscalculator /usr/local/tomcat/.OpenMRS/obscalculator
+ln -sf /etc/bahmni_config/openmrs/ordertemplates /usr/local/tomcat/.OpenMRS/ordertemplates
+ln -sf /etc/bahmni_config/openmrs/encounterModifier /usr/local/tomcat/.OpenMRS/encounterModifier
+ln -sf /etc/bahmni_config/openmrs/patientMatchingAlgorithm /usr/local/tomcat/.OpenMRS/patientMatchingAlgorithm
+ln -sf /etc/bahmni_config/openmrs/elisFeedInterceptor /usr/local/tomcat/.OpenMRS/elisFeedInterceptor
+ln -sf /etc/bahmni_config /usr/local/tomcat/.OpenMRS/bahmni_config
 
 # Running Migrations from bahmni_config (Moved from bahmni-web postinstall)
 cd /etc/bahmni_config/openmrs/migrations/


### PR DESCRIPTION
tl;dr: Added ```-f``` (force) to the ```ln -s```  commands in order to support consecutive runs.

Reason: I had some issues running Bahmni using docker compose. The "ln -s" commands in the ```bahmni_startup.sh``` file fails if the target files already exist in the volume. That causes the openers container to exit(1) and subsequently
```docker compose up``` only works the first time it runs. This is the first time I'm trying to install Bahmni, so maybe I'm missing something obvious? :shrug:

I've experienced the problems in both docker on Windows 11 and on MacOs (docker compose v2.3.3).
