### PR TITLE
BAH-1303 | fix. move soft link creation to Dockerfile

### DIFF
--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -23,6 +23,14 @@ RUN cp /tmp/artifacts/atomfeed-client-*.jar /etc/bahmni-lab-connect/atomfeed-cli
 RUN cp /tmp/artifacts/liquibase-core-*.jar /etc/bahmni-lab-connect/liquibase-core.jar
 RUN cp -r /tmp/artifacts/default_config/. /etc/bahmni_config/
 
+# Setting Soft Links from bahmni_config (Moved from bahmni-web postinstall)
+RUN ln -s /etc/bahmni_config/openmrs/obscalculator /usr/local/tomcat/.OpenMRS/obscalculator
+RUN ln -s /etc/bahmni_config/openmrs/ordertemplates /usr/local/tomcat/.OpenMRS/ordertemplates
+RUN ln -s /etc/bahmni_config/openmrs/encounterModifier /usr/local/tomcat/.OpenMRS/encounterModifier
+RUN ln -s /etc/bahmni_config/openmrs/patientMatchingAlgorithm /usr/local/tomcat/.OpenMRS/patientMatchingAlgorithm
+RUN ln -s /etc/bahmni_config/openmrs/elisFeedInterceptor /usr/local/tomcat/.OpenMRS/elisFeedInterceptor
+RUN ln -s /etc/bahmni_config /usr/local/tomcat/.OpenMRS/bahmni_config
+
 # Creating Upload Directories
 RUN mkdir -p /home/bahmni/patient_images
 RUN mkdir -p /home/bahmni/document_images

--- a/package/docker/openmrs/bahmni_startup.sh
+++ b/package/docker/openmrs/bahmni_startup.sh
@@ -16,14 +16,6 @@ envsubst < /etc/bahmni-emr/templates/bahmnicore.properties.template > /usr/local
 # Running Atomfeed Migrations
 java $CHANGE_LOG_TABLE -jar $LIQUIBASE_JAR --driver=$DRIVER --url=$URL --username=$DB_USERNAME --password=$DB_PASSWORD --classpath=/etc/bahmni-lab-connect/atomfeed-client.jar:/usr/local/tomcat/webapps/openmrs.war --changeLogFile=sql/db_migrations.xml update
 
-# Setting Soft Links from bahmni_config (Moved from bahmni-web postinstall)
-ln -s /etc/bahmni_config/openmrs/obscalculator /usr/local/tomcat/.OpenMRS/obscalculator
-ln -s /etc/bahmni_config/openmrs/ordertemplates /usr/local/tomcat/.OpenMRS/ordertemplates
-ln -s /etc/bahmni_config/openmrs/encounterModifier /usr/local/tomcat/.OpenMRS/encounterModifier
-ln -s /etc/bahmni_config/openmrs/patientMatchingAlgorithm /usr/local/tomcat/.OpenMRS/patientMatchingAlgorithm
-ln -s /etc/bahmni_config/openmrs/elisFeedInterceptor /usr/local/tomcat/.OpenMRS/elisFeedInterceptor
-ln -s /etc/bahmni_config /usr/local/tomcat/.OpenMRS/bahmni_config
-
 # Running Migrations from bahmni_config (Moved from bahmni-web postinstall)
 cd /etc/bahmni_config/openmrs/migrations/
 java $CHANGE_LOG_TABLE -jar $LIQUIBASE_JAR --driver=$DRIVER --url=$URL --username=$DB_USERNAME --password=$DB_PASSWORD --classpath=/usr/local/tomcat/webapps/openmrs.war --changeLogFile=liquibase.xml update


### PR DESCRIPTION
When restarting OpenMRS container the soft link creation step fails and that step can be done only once in the build step. Hence moving the steps to Dockerfile from startup script.