### PR TITLE
Bah 1649 - Upgrades openmrs version to 2.4.2 and upgrades module versions compatible to openmrs:2.4.2

### DIFF
--- a/.github/workflows/build_publish_openmrs.yml
+++ b/.github/workflows/build_publish_openmrs.yml
@@ -70,49 +70,49 @@ jobs:
           push: true
           tags: bahmni/openmrs:OMRS-master-2.4
 
-  helm-package-publish:
-      name: Helm Package & Publish
-      runs-on: ubuntu-latest
-      needs: [get-version, docker-build-publish]
-      env:
-        ARTIFACT_VERSION: ${{ needs.get-version.outputs.version }}
-        HELM_CHART_PATH: openmrs-distro-bahmni/package/helm/openmrs
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v2
-          with:
-            path: openmrs-distro-bahmni
-        - name: Update Version and Image Tag
-          run: |
-            yq --inplace '.image.tag = "${{ env.ARTIFACT_VERSION }}"' $HELM_CHART_PATH/values.yaml
-            yq --inplace '.version = "${{ env.ARTIFACT_VERSION }}"' $HELM_CHART_PATH/Chart.yaml
-
-        - name: Helm Lint
-          run: helm lint $HELM_CHART_PATH
-
-        - name: Helm Package
-          run: helm package $HELM_CHART_PATH
-
-        - name: Checkout Charts Repository
-          uses: actions/checkout@v2
-          with:
-            repository: Bahmni/helm-charts
-            ref: gh-pages
-            path: helm-charts
-            persist-credentials: false
-
-        - name: Copy Helm Archive
-          run: cp openmrs-${{ env.ARTIFACT_VERSION }}.tgz helm-charts/openmrs/
-
-        - name: Helm Index
-          working-directory: helm-charts/
-          run: helm repo index --merge index.yaml --url https://bahmni.github.io/helm-charts/  .
-
-        - name: Commit and Push Chart Repository
-          working-directory: helm-charts/
-          run: |
-            git config user.name ${{ secrets.BAHMNI_USERNAME}}
-            git config user.email ${{ secrets.BAHMNI_EMAIL}}
-            git add .
-            git commit -m "Release of openmrs-${{ env.ARTIFACT_VERSION }}"
-            git push 'https://${{ secrets.BAHMNI_USERNAME}}:${{ secrets.BAHMNI_PAT}}@github.com/bahmni/helm-charts.git' gh-pages
+#  helm-package-publish:
+#      name: Helm Package & Publish
+#      runs-on: ubuntu-latest
+#      needs: [get-version, docker-build-publish]
+#      env:
+#        ARTIFACT_VERSION: ${{ needs.get-version.outputs.version }}
+#        HELM_CHART_PATH: openmrs-distro-bahmni/package/helm/openmrs
+#      steps:
+#        - name: Checkout
+#          uses: actions/checkout@v2
+#          with:
+#            path: openmrs-distro-bahmni
+#        - name: Update Version and Image Tag
+#          run: |
+#            yq --inplace '.image.tag = "${{ env.ARTIFACT_VERSION }}"' $HELM_CHART_PATH/values.yaml
+#            yq --inplace '.version = "${{ env.ARTIFACT_VERSION }}"' $HELM_CHART_PATH/Chart.yaml
+#
+#        - name: Helm Lint
+#          run: helm lint $HELM_CHART_PATH
+#
+#        - name: Helm Package
+#          run: helm package $HELM_CHART_PATH
+#
+#        - name: Checkout Charts Repository
+#          uses: actions/checkout@v2
+#          with:
+#            repository: Bahmni/helm-charts
+#            ref: gh-pages
+#            path: helm-charts
+#            persist-credentials: false
+#
+#        - name: Copy Helm Archive
+#          run: cp openmrs-${{ env.ARTIFACT_VERSION }}.tgz helm-charts/openmrs/
+#
+#        - name: Helm Index
+#          working-directory: helm-charts/
+#          run: helm repo index --merge index.yaml --url https://bahmni.github.io/helm-charts/  .
+#
+#        - name: Commit and Push Chart Repository
+#          working-directory: helm-charts/
+#          run: |
+#            git config user.name ${{ secrets.BAHMNI_USERNAME}}
+#            git config user.email ${{ secrets.BAHMNI_EMAIL}}
+#            git add .
+#            git commit -m "Release of openmrs-${{ env.ARTIFACT_VERSION }}"
+#            git push 'https://${{ secrets.BAHMNI_USERNAME}}:${{ secrets.BAHMNI_PAT}}@github.com/bahmni/helm-charts.git' gh-pages

--- a/.github/workflows/build_publish_openmrs.yml
+++ b/.github/workflows/build_publish_openmrs.yml
@@ -1,7 +1,7 @@
 name: Build and Publish OpenMRS
 on:
   push:
-    branches: [ master ]
+    branches: [ OMRS-master-2.4 ]
     paths-ignore:
       - "**.md"
       - ".github/workflows/build_publish_openmrs_freshDB.yml"
@@ -68,7 +68,7 @@ jobs:
           context: .
           file: package/docker/openmrs/Dockerfile
           push: true
-          tags: bahmni/openmrs:${{ env.ARTIFACT_VERSION }},bahmni/openmrs:latest
+          tags: bahmni/openmrs:OMRS-master-2.4
 
   helm-package-publish:
       name: Helm Package & Publish

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -20,7 +20,7 @@
         <atomfeedModuleVersion>2.6.1</atomfeedModuleVersion>
         <bacteriologyVersion>1.3.0.1-SNAPSHOT</bacteriologyVersion>
         <auditLogVersion>1.3.0.1-SNAPSHOT</auditLogVersion>
-        <bahmniCoreVersion>0.94-SNAPSHOT</bahmniCoreVersion>
+        <bahmniCoreVersion>0.94.1-SNAPSHOT</bahmniCoreVersion>
         <bedManagementVersion>5.13.0</bedManagementVersion>
         <calculationVersion>1.3.0</calculationVersion>
         <emrapiModuleVersion>1.32.0</emrapiModuleVersion>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -31,7 +31,7 @@
         <idgenModuleVersion>4.7.0</idgenModuleVersion>
         <idgenWebServicesModuleVersion>1.3-SNAPSHOT</idgenWebServicesModuleVersion>
         <legacyUiOmodVersion>1.8.4</legacyUiOmodVersion>
-        <mailappenderVersion>0.94.2</mailappenderVersion>
+        <mailappenderVersion>0.94.3.1-SNAPSHOT</mailappenderVersion>
         <metadataMappingVersion>1.4.0</metadataMappingVersion>
         <metadataSharingVersion>1.8.0</metadataSharingVersion>
         <openMRSVersion>2.4.2</openMRSVersion>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -15,40 +15,40 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <addressHierarchyVersion>2.9</addressHierarchyVersion>
-        <appframeworkModuleVersion>2.10.0</appframeworkModuleVersion>
+        <addressHierarchyVersion>2.14.2</addressHierarchyVersion>
+        <appframeworkModuleVersion>2.16.0</appframeworkModuleVersion>
         <atomfeedModuleVersion>2.6.1</atomfeedModuleVersion>
-        <bacteriologyVersion>1.2.0</bacteriologyVersion>
-        <auditLogVersion>1.2.0</auditLogVersion>
+        <bacteriologyVersion>1.3.1-SNAPSHOT</bacteriologyVersion>
+        <auditLogVersion>1.3.0-SNAPSHOT</auditLogVersion>
         <bahmniCoreVersion>0.94-SNAPSHOT</bahmniCoreVersion>
-        <bedManagementVersion>5.12.0</bedManagementVersion>
-        <calculationVersion>1.2</calculationVersion>
-        <emrapiModuleVersion>1.24.8</emrapiModuleVersion>
-        <episodesVersion>1.0-SNAPSHOT</episodesVersion>
-        <eventModuleVersion>2.8.0</eventModuleVersion>
-        <owaVersion>1.9.0</owaVersion>
-        <htmlwidgetsVersion>1.8.0</htmlwidgetsVersion>
-        <idgenModuleVersion>4.4.1</idgenModuleVersion>
-        <idgenWebServicesModuleVersion>1.2-SNAPSHOT</idgenWebServicesModuleVersion>
-        <legacyUiOmodVersion>1.10.0</legacyUiOmodVersion>
+        <bedManagementVersion>5.13.0</bedManagementVersion>
+        <calculationVersion>1.3.0</calculationVersion>
+        <emrapiModuleVersion>1.32.0</emrapiModuleVersion>
+        <episodesVersion>1.0.1-SNAPSHOT</episodesVersion>
+        <eventModuleVersion>2.10.0</eventModuleVersion>
+        <owaVersion>1.7.0</owaVersion>
+        <htmlwidgetsVersion>1.10.0</htmlwidgetsVersion>
+        <idgenModuleVersion>4.7.0</idgenModuleVersion>
+        <idgenWebServicesModuleVersion>1.3-SNAPSHOT</idgenWebServicesModuleVersion>
+        <legacyUiOmodVersion>1.8.4</legacyUiOmodVersion>
         <mailappenderVersion>0.94.2</mailappenderVersion>
-        <metadataMappingVersion>1.3.1</metadataMappingVersion>
-        <metadataSharingVersion>1.2.2</metadataSharingVersion>
+        <metadataMappingVersion>1.4.0</metadataMappingVersion>
+        <metadataSharingVersion>1.8.0</metadataSharingVersion>
         <openMRSVersion>2.4.2</openMRSVersion>
         <operationTheaterVersion>1.4.0</operationTheaterVersion>
-        <providerManagementVersion>2.5.0</providerManagementVersion>
-        <rulesEngineVersion>0.94-SNAPSHOT</rulesEngineVersion>
-        <reportingVersion>1.16.0</reportingVersion>
-        <serializationVersion>0.2.12</serializationVersion>
-        <uicommonsModuleVersion>2.0</uicommonsModuleVersion>
-        <uiframeworkModuleVersion>3.8</uiframeworkModuleVersion>
-        <uilibraryVersion>2.0.5</uilibraryVersion>
+        <providerManagementVersion>2.13.0</providerManagementVersion>
+        <rulesEngineVersion>0.94.1-SNAPSHOT</rulesEngineVersion>
+        <reportingVersion>1.23.0</reportingVersion>
+        <serializationVersion>0.2.15</serializationVersion>
+        <uicommonsModuleVersion>2.19.0</uicommonsModuleVersion>
+        <uiframeworkModuleVersion>3.22.0</uiframeworkModuleVersion>
+        <uilibraryVersion>2.0.7</uilibraryVersion>
         <webServicesRestVersion>2.33.0</webServicesRestVersion>
-        <reportingRestVersion>1.10.0</reportingRestVersion>
-        <bahmniIEOmodVersion>1.2.0</bahmniIEOmodVersion>
+        <reportingRestVersion>1.12.0</reportingRestVersion>
+        <bahmniIEOmodVersion>1.3.1-SNAPSHOT</bahmniIEOmodVersion>
         <appointmentsVersion>1.4.0</appointmentsVersion>
         <pacsQueryVersion>1.2.0</pacsQueryVersion>
-        <fhir2ModuleVersion>1.4.0-SNAPSHOT</fhir2ModuleVersion>
+        <fhir2ModuleVersion>1.2.2</fhir2ModuleVersion>
         <fhir2ExtensionModuleVersion>1.1.0-SNAPSHOT</fhir2ExtensionModuleVersion>
     </properties>
 

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <addressHierarchyVersion>2.14.2</addressHierarchyVersion>
         <appframeworkModuleVersion>2.16.0</appframeworkModuleVersion>
-        <atomfeedModuleVersion>2.6.1</atomfeedModuleVersion>
+        <atomfeedModuleVersion>2.6.2-SNAPSHOT</atomfeedModuleVersion>
         <bacteriologyVersion>1.3.0.1-SNAPSHOT</bacteriologyVersion>
         <auditLogVersion>1.3.0.1-SNAPSHOT</auditLogVersion>
         <bahmniCoreVersion>0.94.1-SNAPSHOT</bahmniCoreVersion>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -18,7 +18,7 @@
         <addressHierarchyVersion>2.14.2</addressHierarchyVersion>
         <appframeworkModuleVersion>2.16.0</appframeworkModuleVersion>
         <atomfeedModuleVersion>2.6.1</atomfeedModuleVersion>
-        <bacteriologyVersion>1.3.1-SNAPSHOT</bacteriologyVersion>
+        <bacteriologyVersion>1.3.0.1-SNAPSHOT</bacteriologyVersion>
         <auditLogVersion>1.3.0-SNAPSHOT</auditLogVersion>
         <bahmniCoreVersion>0.94-SNAPSHOT</bahmniCoreVersion>
         <bedManagementVersion>5.13.0</bedManagementVersion>
@@ -45,9 +45,9 @@
         <uilibraryVersion>2.0.7</uilibraryVersion>
         <webServicesRestVersion>2.33.0</webServicesRestVersion>
         <reportingRestVersion>1.12.0</reportingRestVersion>
-        <bahmniIEOmodVersion>1.3.1-SNAPSHOT</bahmniIEOmodVersion>
+        <bahmniIEOmodVersion>1.3.0.1-SNAPSHOT</bahmniIEOmodVersion>
         <appointmentsVersion>1.4.0</appointmentsVersion>
-        <pacsQueryVersion>1.3.1-SNAPSHOT</pacsQueryVersion>
+        <pacsQueryVersion>1.3.0.1-SNAPSHOT</pacsQueryVersion>
         <fhir2ModuleVersion>1.2.2</fhir2ModuleVersion>
         <fhir2ExtensionModuleVersion>1.1.0-SNAPSHOT</fhir2ExtensionModuleVersion>
     </properties>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -47,7 +47,7 @@
         <reportingRestVersion>1.12.0</reportingRestVersion>
         <bahmniIEOmodVersion>1.3.1-SNAPSHOT</bahmniIEOmodVersion>
         <appointmentsVersion>1.4.0</appointmentsVersion>
-        <pacsQueryVersion>1.2.0</pacsQueryVersion>
+        <pacsQueryVersion>1.3.1-SNAPSHOT</pacsQueryVersion>
         <fhir2ModuleVersion>1.2.2</fhir2ModuleVersion>
         <fhir2ExtensionModuleVersion>1.1.0-SNAPSHOT</fhir2ExtensionModuleVersion>
     </properties>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -35,7 +35,7 @@
         <metadataMappingVersion>1.4.0</metadataMappingVersion>
         <metadataSharingVersion>1.8.0</metadataSharingVersion>
         <openMRSVersion>2.4.2</openMRSVersion>
-        <operationTheaterVersion>1.4.0</operationTheaterVersion>
+        <operationTheaterVersion>1.5.0</operationTheaterVersion>
         <providerManagementVersion>2.13.0</providerManagementVersion>
         <rulesEngineVersion>0.94.1-SNAPSHOT</rulesEngineVersion>
         <reportingVersion>1.23.0</reportingVersion>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -34,7 +34,7 @@
         <mailappenderVersion>0.94.2</mailappenderVersion>
         <metadataMappingVersion>1.3.1</metadataMappingVersion>
         <metadataSharingVersion>1.2.2</metadataSharingVersion>
-        <openMRSVersion>2.1.7</openMRSVersion>
+        <openMRSVersion>2.4.2</openMRSVersion>
         <operationTheaterVersion>1.4.0</operationTheaterVersion>
         <providerManagementVersion>2.5.0</providerManagementVersion>
         <rulesEngineVersion>0.94-SNAPSHOT</rulesEngineVersion>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -19,7 +19,7 @@
         <appframeworkModuleVersion>2.16.0</appframeworkModuleVersion>
         <atomfeedModuleVersion>2.6.1</atomfeedModuleVersion>
         <bacteriologyVersion>1.3.0.1-SNAPSHOT</bacteriologyVersion>
-        <auditLogVersion>1.3.0-SNAPSHOT</auditLogVersion>
+        <auditLogVersion>1.3.0.1-SNAPSHOT</auditLogVersion>
         <bahmniCoreVersion>0.94-SNAPSHOT</bahmniCoreVersion>
         <bedManagementVersion>5.13.0</bedManagementVersion>
         <calculationVersion>1.3.0</calculationVersion>
@@ -35,7 +35,7 @@
         <metadataMappingVersion>1.4.0</metadataMappingVersion>
         <metadataSharingVersion>1.8.0</metadataSharingVersion>
         <openMRSVersion>2.4.2</openMRSVersion>
-        <operationTheaterVersion>1.5.0</operationTheaterVersion>
+        <operationTheaterVersion>1.6.0</operationTheaterVersion>
         <providerManagementVersion>2.13.0</providerManagementVersion>
         <rulesEngineVersion>0.94.1-SNAPSHOT</rulesEngineVersion>
         <reportingVersion>1.23.0</reportingVersion>

--- a/openmrs-module-bahmni.configuration/pom.xml
+++ b/openmrs-module-bahmni.configuration/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <openMRSVersion>2.1.6</openMRSVersion>
+        <openMRSVersion>2.4.2</openMRSVersion>
         <MODULE_ID>${project.parent.artifactId}</MODULE_ID>
         <MODULE_NAME>${project.parent.name}</MODULE_NAME>
         <MODULE_VERSION>${project.parent.version}</MODULE_VERSION>


### PR DESCRIPTION
This PR is about - 
- Upgrades openmrs version to 2.4.2 and upgrades module versions compatible to openmrs:2.4.2
- Changes branch name as OMRS-master-2.4 in github workflow 