### PR TITLE
OTM-3 | Updates operation theater version

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -35,7 +35,7 @@
         <metadataMappingVersion>1.3.1</metadataMappingVersion>
         <metadataSharingVersion>1.2.2</metadataSharingVersion>
         <openMRSVersion>2.1.7</openMRSVersion>
-        <operationTheaterVersion>1.4.0</operationTheaterVersion>
+        <operationTheaterVersion>1.6.0</operationTheaterVersion>
         <providerManagementVersion>2.5.0</providerManagementVersion>
         <rulesEngineVersion>0.94-SNAPSHOT</rulesEngineVersion>
         <reportingVersion>1.16.0</reportingVersion>


### PR DESCRIPTION
This PR updates Operation Thaeter module version to 1.6.0 to incorporate the fix for [OTM-3](https://issues.openmrs.org/browse/OTM-3) issue.