### PR TITLE
BAH-1932 [Docker] Liquibase migrations are not running due to excluded dependency of "logback-classic" from liquibase-core in openmrs-core

### DIFF
--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -2,7 +2,8 @@ FROM openmrs/openmrs-distro-platform:2.4.2
 
 ENV ATOMFEED_CLIENT_VERSION=1.10.1
 ENV LIQUIBASE_VERSION=3.10.2
-
+ENV LOGBACK_CORE_VERSION=1.2.3
+ENV SLF4J_API_VERSION=1.7.28
 # Creating Config Directories
 RUN mkdir -p /usr/local/tomcat/.OpenMRS/modules/
 RUN mkdir -p /tmp/artifacts/default_config/
@@ -12,7 +13,8 @@ RUN mkdir -p /etc/bahmni-lab-connect/
 # Downloading atomfeed client and liquibase core
 RUN curl -L -o /tmp/artifacts/atomfeed-client-${ATOMFEED_CLIENT_VERSION}.jar "https://oss.sonatype.org/content/repositories/releases/org/ict4h/atomfeed-client/${ATOMFEED_CLIENT_VERSION}/atomfeed-client-${ATOMFEED_CLIENT_VERSION}.jar"
 RUN curl -L -o /tmp/artifacts/liquibase-core-${LIQUIBASE_VERSION}.jar "https://oss.sonatype.org/content/repositories/releases/org/liquibase/liquibase-core/${LIQUIBASE_VERSION}/liquibase-core-${LIQUIBASE_VERSION}.jar"
-
+RUN curl -L -o /tmp/artifacts/logback-core-${LOGBACK_CORE_VERSION}.jar "https://repo1.maven.org/maven2/ch/qos/logback/logback-core/${LOGBACK_CORE_VERSION}/logback-core-${LOGBACK_CORE_VERSION}.jar"
+RUN curl -L -o /tmp/artifacts/slf4j-api-${SLF4J_API_VERSION}.jar "https://repo1.maven.org/maven2/org/slf4j/slf4j-api/${SLF4J_API_VERSION}/slf4j-api-${SLF4J_API_VERSION}.jar"
 #unzip default_config
 ADD package/resources/default_config.zip /tmp/artifacts/
 RUN unzip -d /tmp/artifacts/default_config/ /tmp/artifacts/default_config.zip
@@ -29,6 +31,8 @@ COPY package/docker/openmrs/resources/*.omod /usr/local/tomcat/.OpenMRS/modules/
 
 RUN cp /tmp/artifacts/atomfeed-client-*.jar /etc/bahmni-lab-connect/atomfeed-client.jar
 RUN cp /tmp/artifacts/liquibase-core-*.jar /etc/bahmni-lab-connect/liquibase-core.jar
+RUN cp /tmp/artifacts/logback-core-*.jar /etc/bahmni-lab-connect/logback-core.jar
+RUN cp /tmp/artifacts/slf4j-api-*.jar /etc/bahmni-lab-connect/slf4j-api.jar
 RUN cp -r /tmp/artifacts/default_config/. /etc/bahmni_config/
 
 # Setting Soft Links from bahmni_config (Moved from bahmni-web postinstall)

--- a/package/docker/openmrs/bahmni_startup.sh
+++ b/package/docker/openmrs/bahmni_startup.sh
@@ -4,10 +4,16 @@ set -e
 # This script is used to run startup commands before starting OpenMRS distro startup script that comes with docker image. The last line starts OpenMRS script.
 echo "Running Bahmnni EMR Startup Script..."
 
+JAR_DIR="/etc/bahmni-lab-connect"
+LIQUIBASE_JAR="$JAR_DIR/liquibase-core.jar"
+ATOMFEED_CLIENT_JAR="$JAR_DIR/atomfeed-client.jar"
+LOGBACK_CORE_JAR="$JAR_DIR/logback-core.jar"
+SLF4J_API_JAR="$JAR_DIR/slf4j-api.jar"
+
 CHANGE_LOG_TABLE="-Dliquibase.databaseChangeLogTableName=liquibasechangelog -Dliquibase.databaseChangeLogLockTableName=liquibasechangeloglock -DschemaName=${DB_DATABASE}"
-LIQUIBASE_JAR="/etc/bahmni-lab-connect/liquibase-core.jar"
-DRIVER="com.mysql.jdbc.Driver"
+DRIVER="com.mysql.cj.jdbc.Driver"
 URL="jdbc:mysql://$DB_HOST:3306/${DB_DATABASE} --username=$DB_USERNAME --password=$DB_PASSWORD"
+CLASS_PATH="$LIQUIBASE_JAR:$ATOMFEED_CLIENT_JAR:/usr/local/tomcat/webapps/openmrs.war:$LOGBACK_CORE_JAR:$SLF4J_API_JAR"
 
 echo "Substituting Environment Variables..."
 envsubst < /etc/bahmni-emr/templates/bahmnicore.properties.template > /usr/local/tomcat/.OpenMRS/bahmnicore.properties
@@ -15,7 +21,7 @@ envsubst < /etc/bahmni-emr/templates/openmrs-runtime.properties.template > /usr/
 /usr/local/tomcat/wait-for-it.sh --timeout=3600 ${DB_HOST}:3306
 
 # Running Atomfeed Migrations
-# java $CHANGE_LOG_TABLE -jar $LIQUIBASE_JAR --driver=$DRIVER --url=$URL --username=$DB_USERNAME --password=$DB_PASSWORD --classpath=/etc/bahmni-lab-connect/atomfeed-client.jar:/usr/local/tomcat/webapps/openmrs.war --changeLogFile=sql/db_migrations.xml update
+java $CHANGE_LOG_TABLE -cp $CLASS_PATH liquibase.integration.commandline.Main --driver=$DRIVER --url=$URL --username=$DB_USERNAME --password=$DB_PASSWORD --classpath=$ATOMFEED_CLIENT_JAR:/usr/local/tomcat/webapps/openmrs.war --changeLogFile=sql/db_migrations.xml update
 
 echo "Running OpenMRS Startup Script..."
 ./startup.sh


### PR DESCRIPTION
### Summary:

This is a story. https://bahmni.atlassian.net/browse/BAH-1932
Liquibase migrations are not running due to excluded dependency of "logback-classic" from liquibase-core in openmrs-core

### Solution
Add missing dependencies that have been generated due to version upgrade.
Update command to add missing libraries to classpath

## The following changes have been made:

- udpated
Dockerfile
bahmni_startup.sh


### Testing
The screenshots for successful docker run has been added on the ticket