### PR TITLE
BAH-1679 | Add SQL command to trigger search index rebuild

### DIFF
--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir -p /home/bahmni/document_images
 COPY package/resources/blank-user.png /etc/bahmni/
 
 # Used by envsubst command for replacing environment values at runtime
-RUN apt-get update && apt-get install gettext-base
+RUN apt-get update && apt-get install gettext-base mysql-client -y
 
 COPY package/docker/openmrs/bahmni_startup.sh /usr/local/tomcat/
 RUN chmod +x /usr/local/tomcat/bahmni_startup.sh

--- a/package/docker/openmrs/bahmni_startup.sh
+++ b/package/docker/openmrs/bahmni_startup.sh
@@ -17,5 +17,7 @@ envsubst < /etc/bahmni-emr/templates/openmrs-runtime.properties.template > /usr/
 # Running Atomfeed Migrations
 # java $CHANGE_LOG_TABLE -jar $LIQUIBASE_JAR --driver=$DRIVER --url=$URL --username=$DB_USERNAME --password=$DB_PASSWORD --classpath=/etc/bahmni-lab-connect/atomfeed-client.jar:/usr/local/tomcat/webapps/openmrs.war --changeLogFile=sql/db_migrations.xml update
 
+mysql --host="${DB_HOST}" --user="${DB_USERNAME}" --password="${DB_PASSWORD}" "${DB_DATABASE}" -e "UPDATE global_property SET global_property.property_value = '' WHERE  global_property.property = 'search.indexVersion';" || true
+
 echo "Running OpenMRS Startup Script..."
 ./startup.sh


### PR DESCRIPTION
This PR adds a MySQL command that clears the value of `searchIndex.Version` Global property on every restart, which would eventually trigger a search index rebuild. 

Other approach: 
There is also [REST endpoint](https://rest.openmrs.org/?javascript#update-search-index) exposed by OpenMRS to trigger a rebuild, but it is difficult to trigger it on every restart and this would also need authentication. 

Reference: 
1. JIRA : https://bahmni.atlassian.net/browse/BAH-1679
2. https://talk.openmrs.org/t/rebuild-search-index-from-mysql-or-maven/4446/11
3. https://github.com/openmrs/openmrs-core/blob/2.3.0/api/src/main/java/org/openmrs/util/OpenmrsConstants.java#L597