### PR TITLE
Bindu | BAH-2028 | commons-io mvn dependency from fhir2 module conflicts with openmrs-core

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -48,7 +48,7 @@
         <bahmniIEOmodVersion>1.3.0-SNAPSHOT</bahmniIEOmodVersion>
         <appointmentsVersion>1.6.0-SNAPSHOT</appointmentsVersion>
         <pacsQueryVersion>1.3.0-SNAPSHOT</pacsQueryVersion>
-        <fhir2ModuleVersion>1.4.0</fhir2ModuleVersion>
+        <fhir2ModuleVersion>1.5.0</fhir2ModuleVersion>
         <fhir2ExtensionModuleVersion>1.1.0-SNAPSHOT</fhir2ExtensionModuleVersion>
         <openConceptLabVersion>1.3.0</openConceptLabVersion>
         <initializerModuleVersion>2.3.0-SNAPSHOT</initializerModuleVersion>

--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -26,7 +26,6 @@ COPY package/docker/openmrs/templates/openmrs-runtime.properties.template /etc/b
 # Add the latest ot, fhir and web-services modules with OMRS:2.4.2 changes
 RUN rm /usr/local/tomcat/.OpenMRS/modules/operationtheater*.omod
 RUN rm /usr/local/tomcat/.OpenMRS/modules/webservices.rest*.omod
-RUN rm /usr/local/tomcat/.OpenMRS/modules/fhir2*.omod
 COPY package/docker/openmrs/resources/*.omod /usr/local/tomcat/.OpenMRS/modules/
 
 RUN cp /tmp/artifacts/atomfeed-client-*.jar /etc/bahmni-lab-connect/atomfeed-client.jar


### PR DESCRIPTION
JIRA card -> [https://bahmni.atlassian.net/browse/BAH-2028](https://bahmni.atlassian.net/browse/BAH-2028)

As part of this PR we are,

- Upgrading fhir2 module from 1.4.0 to 1.5.0

- Removing fhir2 custom module from the resource folder.