### PR TITLE
BAH-2590 - Upgrades legacyui version to 1.13.0 to resolve csrf issue

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -30,7 +30,7 @@
         <htmlwidgetsVersion>1.10.0</htmlwidgetsVersion>
         <idgenModuleVersion>4.7.0</idgenModuleVersion>
         <idgenWebServicesModuleVersion>1.3-SNAPSHOT</idgenWebServicesModuleVersion>
-        <legacyUiOmodVersion>1.8.4</legacyUiOmodVersion>
+        <legacyUiOmodVersion>1.13.0</legacyUiOmodVersion>
         <mailappenderVersion>0.94.3-SNAPSHOT</mailappenderVersion>
         <metadataMappingVersion>1.5.0</metadataMappingVersion>
         <metadataSharingVersion>1.8.0</metadataSharingVersion>


### PR DESCRIPTION
This PR is about:
 - Upgrading legacy ui version to 1.13.0
<img width="908" alt="Screenshot 2022-11-30 at 1 15 05 PM" src="https://user-images.githubusercontent.com/82825674/204751757-60282674-0f48-46bf-a300-6f7038ccccea.png">
