### PR TITLE
Siva Reddy | Caching maven dependencies

### DIFF
--- a/.github/workflows/build_publish_openmrs.yml
+++ b/.github/workflows/build_publish_openmrs.yml
@@ -27,6 +27,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
         run: |
           ./mvnw --no-transfer-progress -U clean install

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -13,6 +13,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
         run: |
           ./mvnw --no-transfer-progress -U clean install


### PR DESCRIPTION
In this PR, caching the maven dependencies which improves the build time based on hash of pom files. If the content of pom.xml changes, GHA build creates hash again.

1st Run: 
<img width="1399" alt="image" src="https://user-images.githubusercontent.com/56538788/220248414-46125166-2341-460b-968a-bd79d08a19ab.png">

2nd Run: 
<img width="1398" alt="image" src="https://user-images.githubusercontent.com/56538788/220249112-5f36d0cb-09ec-4cf7-a160-531a8c7e0c74.png">

