### PR TITLE
BAH-1664 | Updated to retrieve files from uploadedresults path uploaded from labentry module.

### DIFF
--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -68,6 +68,7 @@ RUN ln -s /etc/bahmni_config ${OPENMRS_APPLICATION_DATA_DIRECTORY}/bahmni_config
 # Creating Upload Directories
 RUN mkdir -p /home/bahmni/patient_images
 RUN mkdir -p /home/bahmni/document_images
+RUN mkdir -p /home/bahmni/uploaded_results
 COPY package/resources/blank-user.png /etc/bahmni/
 
 # Used by envsubst command for replacing environment values at runtime

--- a/package/docker/openmrs/bahmni_startup.sh
+++ b/package/docker/openmrs/bahmni_startup.sh
@@ -21,6 +21,7 @@ if [ "${OMRS_DOCKER_ENV}" = 'true' ]
 then
 echo "setting the folder permissions"
 setfacl -d -m o::rx -m g::rx /home/bahmni/document_images/
+setfacl -d -m o::rx -m g::rx /home/bahmni/uploaded_results/
 fi
 
 echo "Running OpenMRS Startup Script..."

--- a/package/docker/openmrs/templates/bahmnicore.properties.template
+++ b/package/docker/openmrs/templates/bahmnicore.properties.template
@@ -4,6 +4,7 @@ bahmnicore.images.directory=/home/bahmni/patient_images
 bahmnicore.images.directory.defaultImage=/etc/bahmni/blank-user.png
 bahmnicore.urls.patientimages=/patient_images
 bahmnicore.documents.baseDirectory=/home/bahmni/document_images
+bahmnicore.documents.lablitebaseDirectory=/home/bahmni/uploaded_results
 
 
 openelis.uri=http://${OPENELIS_HOST}:${OPENELIS_PORT}/


### PR DESCRIPTION
Reports uploaded from labentry module cannot be accessed due to lack of permission so this PR addresses that issue.
We have created a new folder uploaded_results to upload the reports from labentry module and access them in patient dashboard.