### PR TITLE
BAH-2849 | Update versions of Bahmni-core and FHIR2Extension Modules

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -20,7 +20,7 @@
         <atomfeedModuleVersion>2.6.2</atomfeedModuleVersion>
         <bacteriologyVersion>1.3.0</bacteriologyVersion>
         <auditLogVersion>1.3.0</auditLogVersion>
-        <bahmniCoreVersion>1.0.0</bahmniCoreVersion>
+        <bahmniCoreVersion>1.1.0-SNAPSHOT</bahmniCoreVersion>
         <bedManagementVersion>5.13.0</bedManagementVersion>
         <calculationVersion>1.3.0</calculationVersion>
         <emrapiModuleVersion>1.32.0</emrapiModuleVersion>
@@ -49,7 +49,7 @@
         <appointmentsVersion>1.7.0</appointmentsVersion>
         <pacsQueryVersion>1.4.0</pacsQueryVersion>
         <fhir2ModuleVersion>1.8.0</fhir2ModuleVersion>
-        <fhir2ExtensionModuleVersion>1.1.0</fhir2ExtensionModuleVersion>
+        <fhir2ExtensionModuleVersion>1.2.0-SNAPSHOT</fhir2ExtensionModuleVersion>
         <openConceptLabVersion>1.3.0</openConceptLabVersion>
         <initializerModuleVersion>2.4.0</initializerModuleVersion>
         <bahmniCommonsVersion>1.0.0</bahmniCommonsVersion>


### PR DESCRIPTION
This PR updates bahmni core version and fhir2extension module versions to the next snapshots which would allow testing BAH-1664 & BAH-2165