### PR TITLE
BAH-3060 | Environment variable to override c3p0 max size

### DIFF
--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -90,7 +90,7 @@ COPY package/docker/openmrs/config.yml /etc/jvm_metrics/
 RUN chmod +x /etc/jvm_metrics/config.yml
 
 # Modify Startup Script to add Hibernate Properties
-COPY package/docker/resources/add_hibernate_properties.sh add_hibernate_properties.sh
+COPY package/resources/add_hibernate_properties.sh add_hibernate_properties.sh
 RUN chmod +x add_hibernate_properties.sh 
 RUN ./add_hibernate_properties.sh
 RUN rm -rf add_hibernate_properties.sh

--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -89,6 +89,12 @@ RUN cp /tmp/artifacts/jmx_prometheus_javaagent-*.jar /etc/jvm_metrics/jmx_promet
 COPY package/docker/openmrs/config.yml /etc/jvm_metrics/
 RUN chmod +x /etc/jvm_metrics/config.yml
 
+# Modify Startup Script to add Hibernate Properties
+COPY package/docker/resources/add_hibernate_properties.sh add_hibernate_properties.sh
+RUN chmod +x add_hibernate_properties.sh 
+RUN ./add_hibernate_properties.sh
+RUN rm -rf add_hibernate_properties.sh
+
 RUN rm -rf /tmp/artifacts
 
 CMD ["./bahmni_startup.sh"]

--- a/package/helm/openmrs/templates/configMap.yaml
+++ b/package/helm/openmrs/templates/configMap.yaml
@@ -23,3 +23,4 @@ data:
   MAIL_SMTP_HOST: "{{ .Values.config.MAIL_SMTP_HOST }}"
   OMRS_DOCKER_ENV: "{{ .Values.config.OMRS_DOCKER_ENV }}"
   TZ: "{{ .Values.global.TZ }}"
+  OMRS_C3P0_MAX_SIZE: "{{ .Values.config.OMRS_C3P0_MAX_SIZE }}"

--- a/package/helm/openmrs/values.yaml
+++ b/package/helm/openmrs/values.yaml
@@ -43,6 +43,7 @@ config:
   MAIL_SMTP_PORT: ""
   MAIL_SMTP_HOST: ""
   OMRS_DOCKER_ENV: 'false'
+  OMRS_C3P0_MAX_SIZE: 50
 
 secrets:
   OMRS_DB_HOSTNAME: ""

--- a/package/resources/add_hibernate_properties.sh
+++ b/package/resources/add_hibernate_properties.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+sed '/module.allow_web_admin/a\
+c3p0.max_size=${OMRS_C3P0_MAX_SIZE}' ./startup-init.sh > ./startup-init-temp.sh
+
+rm ./startup-init.sh
+mv ./startup-init-temp.sh ./startup-init.sh


### PR DESCRIPTION
- This adds a script to append `c3p0.max_size` property to the openmrs-runtime.properties file.
- Also added the config value to helm charts