### PR TITLE
BAH-3077|Added concepts for rulesengine dropdown

### DIFF
--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -57,6 +57,7 @@ COPY package/docker/openmrs/templates/bahmnicore.properties.template /etc/bahmni
 COPY package/docker/openmrs/templates/openmrs-runtime.properties.template /etc/bahmni-emr/templates/
 COPY package/docker/openmrs/templates/mail-config.properties.template /etc/bahmni-emr/templates/
 COPY package/docker/openmrs/templates/appointment.properties.template /etc/bahmni-emr/templates/
+COPY package/docker/openmrs/templates/rulesengine-concept.properties.template /etc/bahmni-emr/templates/
 
 # Setting Soft Links from bahmni_config (Moved from bahmni-web postinstall)
 RUN ln -s /etc/bahmni_config/openmrs/obscalculator ${OPENMRS_APPLICATION_DATA_DIRECTORY}/obscalculator

--- a/package/docker/openmrs/bahmni_startup.sh
+++ b/package/docker/openmrs/bahmni_startup.sh
@@ -9,6 +9,7 @@ envsubst < /etc/bahmni-emr/templates/bahmnicore.properties.template > ${OPENMRS_
 envsubst < /etc/bahmni-emr/templates/openmrs-runtime.properties.template > ${OPENMRS_APPLICATION_DATA_DIRECTORY}/openmrs-runtime.properties
 envsubst < /etc/bahmni-emr/templates/mail-config.properties.template > ${OPENMRS_APPLICATION_DATA_DIRECTORY}/mail-config.properties
 envsubst < /etc/bahmni-emr/templates/appointment.properties.template > ${OPENMRS_APPLICATION_DATA_DIRECTORY}/appointment.properties
+envsubst < /etc/bahmni-emr/templates/rulesengine-concept.properties.template > ${OPENMRS_APPLICATION_DATA_DIRECTORY}/rulesengine-concept.properties
 /openmrs/wait-for-it.sh --timeout=3600 ${OMRS_DB_HOSTNAME}:3306
 
 echo "Copy Configuration Folder from bahmni_config"

--- a/package/docker/openmrs/templates/rulesengine-concept.properties.template
+++ b/package/docker/openmrs/templates/rulesengine-concept.properties.template
@@ -1,0 +1,2 @@
+concept.weight.uuid=${WEIGHT_CONCEPT_UUID}
+concept.height.uuid=${HEIGHT_CONCEPT_UUID}


### PR DESCRIPTION
Need to bring the dropdown values for rules like mg/kg, mg/m2, customRule. For these dropdown values to be visible. We need to add concept height and weight in rulesengine-concept.properties file present in openmrs data directory.

Jira Link: https://bahmni.atlassian.net/browse/BAH-3077