### PR TITLE
[Parvathy, Rahul] | BAH-3168 | Add. Version Update

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -46,14 +46,14 @@
         <webServicesRestVersion>2.39.0</webServicesRestVersion>
         <reportingRestVersion>1.12.0</reportingRestVersion>
         <bahmniIEOmodVersion>1.3.0</bahmniIEOmodVersion>
-        <appointmentsVersion>1.7.0</appointmentsVersion>
+        <appointmentsVersion>2.0.0-SNAPSHOT</appointmentsVersion>
         <pacsQueryVersion>1.4.0</pacsQueryVersion>
         <fhir2ModuleVersion>1.10.0-SNAPSHOT</fhir2ModuleVersion>
         <fhir2ExtensionModuleVersion>1.3.0-SNAPSHOT</fhir2ExtensionModuleVersion>
         <openConceptLabVersion>2.1.0</openConceptLabVersion>
         <initializerModuleVersion>2.4.0</initializerModuleVersion>
         <bahmniCommonsVersion>1.0.0</bahmniCommonsVersion>
-        <teleconsultationVersion>1.1.0</teleconsultationVersion>
+        <teleconsultationVersion>2.0.0-SNAPSHOT</teleconsultationVersion>
         <communicationVersion>1.1.0</communicationVersion>
 
     </properties>


### PR DESCRIPTION
JIRA -> [BAH-3168](https://bahmni.atlassian.net/browse/BAH-3168)

OpenMRS Team want to package Appointments module with O3. They can’t do that unless the license of this module is compatible with O3. Bahmni Coalition/Community have agreed to make the change to make this module’s license compatible with Bahmni & OMRS licenses. Henceforth the [openmrs-module-appointments](https://github.com/Bahmni/openmrs-module-appointments) and [openmrs-module-teleconsultation](https://github.com/Bahmni/openmrs-module-teleconsultation) gets it's module license changed from AGPLv3 to OpenMRS MPLv2. 

To ensure that the Bahmni LITE/Helm umbrella charts are pulling the new 2.0-snapshot builds of appointment and teleconsultation module, their versions have now been updated to `2.0.0-SNAPSHOT` in this PR.