### PR TITLE
BAH-3378 | Add script to update elis host and port based on .env config

### DIFF
--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -88,6 +88,9 @@ RUN setfacl -d -m o::rx -m g::rx /home/bahmni/document_images/
 COPY package/docker/openmrs/bahmni_startup.sh /openmrs/
 RUN chmod +x /openmrs/bahmni_startup.sh
 
+COPY package/docker/openmrs/update_elis_host_port.sh /openmrs/
+RUN chmod +x /openmrs/update_elis_host_port.sh
+
 RUN cp /tmp/artifacts/jmx_prometheus_javaagent-*.jar /etc/jvm_metrics/jmx_prometheus_javaagent.jar
 COPY package/docker/openmrs/config.yml /etc/jvm_metrics/
 RUN chmod +x /etc/jvm_metrics/config.yml

--- a/package/docker/openmrs/bahmni_startup.sh
+++ b/package/docker/openmrs/bahmni_startup.sh
@@ -18,6 +18,8 @@ then
 fi
 mysql --host="${OMRS_DB_HOSTNAME}" --user="${OMRS_DB_USERNAME}" --password="${OMRS_DB_PASSWORD}" "${OMRS_DB_NAME}" -e "UPDATE global_property SET global_property.property_value = '' WHERE  global_property.property = 'search.indexVersion';" || true
 
+./update_elis_host_port.sh
+
 if [ "${OMRS_DOCKER_ENV}" = 'true' ]
 then
 echo "setting the folder permissions"

--- a/package/docker/openmrs/update_elis_host_port.sh
+++ b/package/docker/openmrs/update_elis_host_port.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set +e
+
+run_sql() {
+  mysql -N -s --host="${OMRS_DB_HOSTNAME}" --user="${OMRS_DB_USERNAME}" --password="${OMRS_DB_PASSWORD}" "${OMRS_DB_NAME}" -e "$1"
+}
+
+if [ $(run_sql "select count(*) from information_schema.tables where table_schema='${OMRS_DB_NAME}' and table_name='markers';") -gt 0 ]
+then
+    echo "Updating OpenELIS Host Port in markers and failed_events table"
+    run_sql "update markers set feed_uri_for_last_read_entry = concat('http://${OPENELIS_HOST}:${OPENELIS_PORT}/openelis/ws/feed/patient',substring(feed_uri_for_last_read_entry, (LENGTH(feed_uri_for_last_read_entry) - LOCATE('/', REVERSE(feed_uri_for_last_read_entry)))+1) ) where feed_uri like '%openelis/ws/feed/patient/recent';"
+    run_sql "update markers set feed_uri = 'http://${OPENELIS_HOST}:${OPENELIS_PORT}/openelis/ws/feed/patient/recent' where feed_uri like '%openelis/ws/feed/patient/recent';"
+    run_sql "update failed_events set feed_uri = 'http://${OPENELIS_HOST}:${OPENELIS_PORT}/openelis/ws/feed/patient/recent' where feed_uri like '%openelis/ws/feed/patient/recent';"
+fi


### PR DESCRIPTION
This script updates the host and port for openelis in the markers and failed events table based on the environment variable configuration. 