### PR TITLE
BAH-2650 | Fix. Recursively apply folder permission for file uploads

### DIFF
--- a/package/docker/openmrs/bahmni_startup.sh
+++ b/package/docker/openmrs/bahmni_startup.sh
@@ -23,8 +23,8 @@ mysql --host="${OMRS_DB_HOSTNAME}" --user="${OMRS_DB_USERNAME}" --password="${OM
 if [ "${OMRS_DOCKER_ENV}" = 'true' ]
 then
 echo "setting the folder permissions"
-setfacl -d -m o::rx -m g::rx /home/bahmni/document_images/
-setfacl -d -m o::rx -m g::rx /home/bahmni/uploaded_results/
+setfacl -R -d -m o::rx -m g::rx /home/bahmni/document_images
+setfacl -R -d -m o::rx -m g::rx /home/bahmni/uploaded_results
 fi
 
 echo "Running OpenMRS Startup Script..."


### PR DESCRIPTION
This is a patch fix for https://bahmni.atlassian.net/browse/BAH-2650 which applies folder permissions recursively for document_images and uploaded_results directory.