### PR TITLE
BAH-3528 | Add. uploaded-files Sub Directory And Set Permissions

### DIFF
--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -72,6 +72,7 @@ RUN ln -s /etc/bahmni_config ${OPENMRS_APPLICATION_DATA_DIRECTORY}/bahmni_config
 RUN mkdir -p /home/bahmni/patient_images
 RUN mkdir -p /home/bahmni/document_images
 RUN mkdir -p /home/bahmni/uploaded_results
+RUN mkdir -p /home/bahmni/uploaded-files
 COPY package/resources/blank-user.png /etc/bahmni/
 
 # Used by envsubst command for replacing environment values at runtime

--- a/package/docker/openmrs/bahmni_startup.sh
+++ b/package/docker/openmrs/bahmni_startup.sh
@@ -25,6 +25,7 @@ then
 echo "setting the folder permissions"
 setfacl -R -d -m o::rx -m g::rx /home/bahmni/document_images
 setfacl -R -d -m o::rx -m g::rx /home/bahmni/uploaded_results
+setfacl -R -d -m o::rx -m g::rx /home/bahmni/uploaded-files
 fi
 
 echo "Running OpenMRS Startup Script..."

--- a/package/helm/openmrs/templates/deployment.yaml
+++ b/package/helm/openmrs/templates/deployment.yaml
@@ -78,6 +78,8 @@ spec:
               name: bahmni-config
             - mountPath: /home/bahmni/uploaded_results
               name: bahmni-uploaded-results
+            - mountPath: /home/bahmni/uploaded-files
+              name: bahmni-uploaded-files
       restartPolicy: Always
       volumes:
       #   - name: openmrs-data
@@ -101,3 +103,6 @@ spec:
         - name: bahmni-uploaded-results
           persistentVolumeClaim:
             claimName: bahmni-uploaded-results-pvc
+        - name: bahmni-uploaded-files
+          persistentVolumeClaim:
+            claimName: bahmni-uploaded-files-pvc


### PR DESCRIPTION
JIRA -> [BAH-3528](https://bahmni.atlassian.net/browse/BAH-3528)

This PR includes the following changes:
1. Added a `mkdir` command to create the `uploaded-files` subdirectory.
2. Set read/write access for the `uploaded-files` folder and the newly created file.