### PR TITLE
BAH-3525 | Add. Configuration Property To Handle Zero date prohibited Error

### DIFF
--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -2,6 +2,7 @@ FROM openmrs/openmrs-core:2.5.12
 
 ENV JMX_PROMETHEUS_JAVAAGENT_VERSION=0.18.0
 ENV OPENMRS_APPLICATION_DATA_DIRECTORY=/openmrs/data
+ENV OMRS_DB_EXTRA_ARGS="&zeroDateTimeBehavior=convertToNull"
 
 USER root
 


### PR DESCRIPTION
JIRA -> [BAH-3525](https://bahmni.atlassian.net/browse/BAH-3525)

This PR addresses the "Zero date value prohibited" error configuring OMRS_DB_EXTRA_ARGS to include `&zeroDateTimeBehavior=convertToNull.

During openmrs runtime, OMRS_DB_EXTRA_ARGS sets zeroDateTimeBehavior=convertToNull in JdbcUrl. Upon boot up, openmrs utilizes its own startup script to define the jdbc url. OMRS_DB_EXTRA_ARGS appends any provided parameters to the end of the url.

By default, the connector throws an exception when encountering zero date values, as it aligns with JDBC and SQL standards. This behavior can be adjusted using the zeroDateTimeBehavior configuration property.