### PR TITLE
BAH-3809 | Add. Bump Operation Theater Version 1.8.0

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -35,7 +35,7 @@
         <metadataMappingVersion>1.5.0</metadataMappingVersion>
         <metadataSharingVersion>1.8.0</metadataSharingVersion>
         <openMRSVersion>2.5.12</openMRSVersion>
-        <operationTheaterVersion>1.8.0-SNAPSHOT</operationTheaterVersion>
+        <operationTheaterVersion>1.8.0</operationTheaterVersion>
         <providerManagementVersion>2.13.0</providerManagementVersion>
         <rulesEngineVersion>1.0.0</rulesEngineVersion>
         <reportingVersion>1.26.0</reportingVersion>


### PR DESCRIPTION
JIRA -> [BAH-3809](https://bahmni.atlassian.net/browse/BAH-3809)

In this PR, the operationtheater dependency has been bumped up from 1.8.0-SNAPSHOT -> 1.8.0. With this upgrade the following changes would be brought into bahmni/openmrs image.
- [BAH-3092](https://bahmni.atlassian.net/browse/BAH-3092 ) | Add. Primary Diagnoses in the Surgical Appointment Resource