### PR TITLE
BAH-3853 | Upgrade FHIR2 module from 1.10.0-SNAPSHOT to 2.1.0

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -48,7 +48,7 @@
         <bahmniIEOmodVersion>1.4.0-SNAPSHOT</bahmniIEOmodVersion>
         <appointmentsVersion>2.0.0-SNAPSHOT</appointmentsVersion>
         <pacsQueryVersion>1.4.0</pacsQueryVersion>
-        <fhir2ModuleVersion>1.10.0-SNAPSHOT</fhir2ModuleVersion>
+        <fhir2ModuleVersion>2.1.0</fhir2ModuleVersion>
         <fhir2ExtensionModuleVersion>1.3.0-SNAPSHOT</fhir2ExtensionModuleVersion>
         <openConceptLabVersion>2.1.0</openConceptLabVersion>
         <initializerModuleVersion>2.5.0</initializerModuleVersion>


### PR DESCRIPTION
This PR updates the FHIR2 module from 1.10.0-SNAPSHOT version to 2.1.0 version. This is needed for the bundling of IPD features into Bahmni Standard distro. Specifically, this brings in the enhancement for FHIR task resource. 

PR raised by Bahmni IPD Team: https://github.com/openmrs/openmrs-module-fhir2/pull/539