### PR TITLE
BAH-4003 | Upgrade bedmanagement module version

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -22,7 +22,7 @@
         <auditLogVersion>1.3.0</auditLogVersion>
         <bahmniCoreVersion>1.2.0-SNAPSHOT</bahmniCoreVersion>
         <bahmniIpdVersion>1.0.0-SNAPSHOT</bahmniIpdVersion>
-        <bedManagementVersion>5.14.0-SNAPSHOT</bedManagementVersion>
+        <bedManagementVersion>6.0.0-SNAPSHOT</bedManagementVersion>
         <calculationVersion>1.3.0</calculationVersion>
         <emrapiModuleVersion>1.35.0-SNAPSHOT</emrapiModuleVersion>
         <episodesVersion>1.1.0</episodesVersion>


### PR DESCRIPTION
This PR upgrades bedmanagement module version from 5.14.0-SNAPSHOT to 6.0.0-SNAPSHOT.

PR has been merged on bahmniapps repo to make it compatible. https://github.com/Bahmni/openmrs-module-bahmniapps/pull/976

JIRA: https://bahmni.atlassian.net/browse/BAH-4003