### PR TITLE
BAH-3806 | Revert. Appointments module version to 2.0.0

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -48,7 +48,7 @@
         <webServicesRestVersion>2.44.0</webServicesRestVersion>
         <reportingRestVersion>1.14.0</reportingRestVersion>
         <bahmniIEOmodVersion>1.4.0</bahmniIEOmodVersion>
-        <appointmentsVersion>2.0.1</appointmentsVersion>
+        <appointmentsVersion>2.0.0</appointmentsVersion>
         <pacsQueryVersion>1.4.0</pacsQueryVersion>
         <fhir2ModuleVersion>2.1.0</fhir2ModuleVersion>
         <fhir2ExtensionModuleVersion>1.3.0</fhir2ExtensionModuleVersion>


### PR DESCRIPTION
This PR rolls-back the appointments module version to 2.0.0 as with 2.0.1 the IPD module fails to load and eventually OpenMRS does not boot up