### PR TITLE
BAH-3806 | Fix. Upgrade SNOMED module to take in patch version

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -57,7 +57,7 @@
         <bahmniCommonsVersion>1.1.0</bahmniCommonsVersion>
         <teleconsultationVersion>2.0.0</teleconsultationVersion>
         <communicationVersion>1.2.0</communicationVersion>
-        <terminologyServicesVersion>1.0.0</terminologyServicesVersion>
+        <terminologyServicesVersion>1.0.1</terminologyServicesVersion>
         <cdssVersion>1.0.0</cdssVersion>
         <reportingCompatibilityVersion>2.0.9</reportingCompatibilityVersion>
     </properties>


### PR DESCRIPTION
This PR upgrades the version of SNOMED Terminology Services module to 1.0.1 to include the patch for version in config.xml of the module