### PR TITLE
Remove auto-appended assembly-id suffix to final distro zip artefact

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -519,6 +519,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
                         <descriptor>${basedir}/src/main/assembly/assembly.xml</descriptor>
                     </descriptors>


### PR DESCRIPTION
This PR intends to avoid appending the assembly Id (distro) to the final distro zip package.
i.e  `distro-1.2.0-SNAPSHOT-distro.zip` ➔ `distro-1.2.0-SNAPSHOT.zip`