### PR TITLE
BAH-4149: Bump Bahmni Core version to 1.3.0-SNAPSHOT and FHIR2 version to 2.3.0-SNAPSHOT.

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -20,7 +20,7 @@
         <atomfeedModuleVersion>2.6.3</atomfeedModuleVersion>
         <bacteriologyVersion>1.3.0</bacteriologyVersion>
         <auditLogVersion>1.3.0</auditLogVersion>
-        <bahmniCoreVersion>1.2.0</bahmniCoreVersion>
+        <bahmniCoreVersion>1.3.0-SNAPSHOT</bahmniCoreVersion>
         <bahmniIpdVersion>1.1.1</bahmniIpdVersion>
         <bedManagementVersion>6.0.0</bedManagementVersion>
         <calculationVersion>1.3.0</calculationVersion>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -50,7 +50,7 @@
         <bahmniIEOmodVersion>1.4.0</bahmniIEOmodVersion>
         <appointmentsVersion>2.0.2</appointmentsVersion>
         <pacsQueryVersion>1.4.0</pacsQueryVersion>
-        <fhir2ModuleVersion>2.1.0</fhir2ModuleVersion>
+        <fhir2ModuleVersion>2.3.0-SNAPSHOT</fhir2ModuleVersion>
         <fhir2ExtensionModuleVersion>1.3.1</fhir2ExtensionModuleVersion>
         <openConceptLabVersion>2.3.0</openConceptLabVersion>
         <initializerModuleVersion>2.7.0</initializerModuleVersion>


### PR DESCRIPTION
This is a follow-on PR based on the changes discussed [here](https://bahmni.slack.com/archives/C03LWT96L/p1732540018086699).

This PR will ensure the following upgrades:

* Bahmni Core 1.3.0-SNAPSHOT allows Bahmni Core liquibase runnable on Maria DB [reference](https://github.com/Bahmni/bahmni-core/pull/280).
* FHIR2 2.3.0-SNAPSHOT fixes the issue with its api failing to access another modules api [reference](https://openmrs.atlassian.net/browse/FM2-651).