### PR TITLE
BAH-4161 | Add. Bump Address Hierarchy Version to 2.19.0

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <addressHierarchyVersion>2.17.0</addressHierarchyVersion>
+        <addressHierarchyVersion>2.19.0</addressHierarchyVersion>
         <appframeworkModuleVersion>2.17.0</appframeworkModuleVersion>
         <atomfeedModuleVersion>2.6.3</atomfeedModuleVersion>
         <bacteriologyVersion>1.3.0</bacteriologyVersion>


### PR DESCRIPTION
2.17.0 -> 2.19.0

JIRA -> [BAH-4161](https://bahmni.atlassian.net/browse/BAH-4161)

This PR upgrades the Address Hierarchy module in Bahmni from version 2.17.0 to the latest version 2.19.0. The Address Hierarchy module upgrade is to leverage new features, improvements, and bug fixes introduced between versions 2.18.0 and 2.19.0.