### PR TITLE
BAH-4153 | Add. Bump openmrs-core Image Version

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -36,7 +36,7 @@
         <medicationAdministrationVersion>1.0.0</medicationAdministrationVersion>
         <metadataMappingVersion>1.6.0</metadataMappingVersion>
         <metadataSharingVersion>1.9.0</metadataSharingVersion>
-        <openMRSVersion>2.5.12</openMRSVersion>
+        <openMRSVersion>2.5.14</openMRSVersion>
         <operationTheaterVersion>1.8.0</operationTheaterVersion>
         <providerManagementVersion>2.14.0</providerManagementVersion>
         <rulesEngineVersion>1.0.0</rulesEngineVersion>

--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmrs/openmrs-core:2.5.12
+FROM openmrs/openmrs-core:2.5.14
 
 ENV JMX_PROMETHEUS_JAVAAGENT_VERSION=0.18.0
 ENV OPENMRS_APPLICATION_DATA_DIRECTORY=/openmrs/data


### PR DESCRIPTION
JIRA -> [BAH-4153](https://bahmni.atlassian.net/browse/BAH-4153)
2.5.12 -> 2.5.14

This PR upgrades the `openmrs-core` base image in Bahmni from version `v2.5.12` to the latest version `v2.5.14`. The `openmrs-core` base image upgrade is to leverage new improvements, and bug fixes introduced between versions `v2.5.12` and `v2.5.14`.

Between `v2.5.12` and `v2.5.14` of the `openmrs-core` base image, mostly stricter privilege checks have been added to enhance security. Missing privilege checks were implemented in services like `ConceptService`, `FormService`, and `DatabaseUpdater`, while `AlertService` now requires proper authorization. Enhancements include protecting admin credentials with runtime properties, ensuring secure handling of sensitive data, and setting the appropriate MIME type for files served by the initialization filter. Other improvements include fixing velocity configuration, resolving issues in `ModuleService` to prevent context refresh blocks, and enabling query caching to boost performance. Additional bug fixes, along with Docker build and Bamboo workflow changes, further improve stability and deployment processes.