### PR TITLE
BAH-4187 | Refactor. Maven Repository Configurations

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -350,47 +350,6 @@
         </pluginRepository>
     </pluginRepositories>
 
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2</url>
-            <name>Repository for dependencies</name>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>openmrs-repo</id>
-            <name>OpenMRS Nexus Repository</name>
-            <url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
-        </repository>
-       <repository>
-           <id>repo.mybahmni.org</id>
-           <name>bahmni-artifactory-snapshots</name>
-           <url>https://repo.mybahmni.org/artifactory/snapshot</url>
-           <snapshots>
-               <updatePolicy>always</updatePolicy>
-           </snapshots>
-       </repository>
-       <repository>
-          <id>repo.mybahmni.org-release</id>
-          <name>bahmni-artifactory-release</name>
-          <url>https://repo.mybahmni.org/artifactory/release</url>
-      </repository>
-
-    </repositories>
-
     <build>
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,14 @@
             </snapshots>
         </repository>
 		<repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <name>Repository for dependencies</name>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+		<repository>
 			<id>openmrs-repo</id>
 			<name>OpenMRS Nexus Repository</name>
 			<url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
 			<name>Mekom Solutions Nexus Snapshots</name>
 			<url>https://nexus.mekomsolutions.net/repository/maven-snapshots</url>
 		</repository>
+		<repository>
+			<id>www.dcm4che.org</id>
+			<name>dcm4che Repository</name>
+			<url>https://www.dcm4che.org/maven2</url>
+    	</repository>
 	</repositories>
 
 	<pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <repository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
This PR updates the SNAPSHOT repository URL of nexus-sonatype to point to the Sonatype Central Portal URL. Also, the duplicate repository configurations are removed from the distro module of the project.