### PR TITLE
BAH-4190 | Fix. Upgrade address hierarchy module version to 2.21.0

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <addressHierarchyVersion>2.19.0</addressHierarchyVersion>
+        <addressHierarchyVersion>2.21.0</addressHierarchyVersion>
         <appframeworkModuleVersion>2.17.0</appframeworkModuleVersion>
         <atomfeedModuleVersion>2.6.3</atomfeedModuleVersion>
         <bacteriologyVersion>1.3.0</bacteriologyVersion>


### PR DESCRIPTION
This PR upgrades the version of address hierarchy module from 2.19.0 to 2.21.0 to resolve issues on the Address Hierarchy Management page from OpenMRS admin page.

Changelog between 2.19.0 and 2.21.0 --> https://github.com/openmrs/openmrs-module-addresshierarchy/compare/2.19.0...2.21.0

JIRA --> https://bahmni.atlassian.net/browse/BAH-4190