### PR TITLE
BAH-4195 | Add. Upgrade FHIR2 module to 2.5.0

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -50,7 +50,7 @@
         <bahmniIEOmodVersion>1.4.0</bahmniIEOmodVersion>
         <appointmentsVersion>2.0.2</appointmentsVersion>
         <pacsQueryVersion>1.4.0</pacsQueryVersion>
-        <fhir2ModuleVersion>2.4.0-SNAPSHOT</fhir2ModuleVersion>
+        <fhir2ModuleVersion>2.5.0</fhir2ModuleVersion>
         <fhir2ExtensionModuleVersion>1.4.0-SNAPSHOT</fhir2ExtensionModuleVersion>
         <openConceptLabVersion>2.3.0</openConceptLabVersion>
         <initializerModuleVersion>2.7.0</initializerModuleVersion>


### PR DESCRIPTION
This PR upgrades the FHIR2 module from 2.4.0-SNAPSHOT to 2.5.0. This is needed to incorporate the Security fixes by OpenMRS team on the module. The @Authrorized annotations are now respected.

Changelog of 2.4.0 to 2.5.0 : https://github.com/openmrs/openmrs-module-fhir2/releases/tag/2.5.0

JIRA: https://bahmni.atlassian.net/browse/BAH-4195