### PR TITLE
BAH-4191 | Upgrade openmrs core version and legacy ui module version

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -31,7 +31,7 @@
         <htmlwidgetsVersion>1.11.0</htmlwidgetsVersion>
         <idgenModuleVersion>4.14.0</idgenModuleVersion>
         <idgenWebServicesModuleVersion>1.4.0</idgenWebServicesModuleVersion>
-        <legacyUiOmodVersion>1.21.0</legacyUiOmodVersion>
+        <legacyUiOmodVersion>1.22.0</legacyUiOmodVersion>
         <mailappenderVersion>1.0.0</mailappenderVersion>
         <medicationAdministrationVersion>1.0.0</medicationAdministrationVersion>
         <metadataMappingVersion>1.6.0</metadataMappingVersion>

--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmrs/openmrs-core:2.5.14
+FROM openmrs/openmrs-core:2.5.x-dev
 
 ENV JMX_PROMETHEUS_JAVAAGENT_VERSION=0.18.0
 ENV OPENMRS_APPLICATION_DATA_DIRECTORY=/openmrs/data

--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmrs/openmrs-core:2.5.x-dev
+FROM openmrs/openmrs-core:2.5.x-nightly
 
 ENV JMX_PROMETHEUS_JAVAAGENT_VERSION=0.18.0
 ENV OPENMRS_APPLICATION_DATA_DIRECTORY=/openmrs/data


### PR DESCRIPTION
This PR updates the legacy ui module version to 1.22.0. This is needed to resolve the issue with address hierarchy mapping issue. Also OpenMRS core docker version is updated to 2.5.x-nightly to include changes that fixes file upload issues across Admin modules