### PR TITLE
BAH-4681 | Fix. Bump atomfeed version to fix feed sync failures

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <addressHierarchyVersion>2.21.0</addressHierarchyVersion>
         <appframeworkModuleVersion>2.17.0</appframeworkModuleVersion>
-        <atomfeedModuleVersion>2.6.3</atomfeedModuleVersion>
+        <atomfeedModuleVersion>2.7.0-SNAPSHOT</atomfeedModuleVersion>
         <bacteriologyVersion>1.3.0</bacteriologyVersion>
         <auditLogVersion>1.3.0</auditLogVersion>
         <bahmniCoreVersion>2.0.0-SNAPSHOT</bahmniCoreVersion>


### PR DESCRIPTION
This PR bumps the Atomfeed version to bring in the changes for fixing the sync restart failures when OpenMRS service is restarted.

Related PR:  https://github.com/ICT4H/openmrs-atomfeed/pull/17/changes

JIRA: https://bahmni.atlassian.net/browse/BAH-4681