### PR TITLE
BAH-4222 | Update bahmniCore version to 2.0.1-SNAPSHOT

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -20,7 +20,7 @@
         <atomfeedModuleVersion>2.7.0-SNAPSHOT</atomfeedModuleVersion>
         <bacteriologyVersion>1.3.0</bacteriologyVersion>
         <auditLogVersion>1.3.0</auditLogVersion>
-        <bahmniCoreVersion>2.0.0-SNAPSHOT</bahmniCoreVersion>
+        <bahmniCoreVersion>2.0.1-SNAPSHOT</bahmniCoreVersion>
         <bahmniIpdVersion>1.2.0-SNAPSHOT</bahmniIpdVersion>
         <bedManagementVersion>6.0.0</bedManagementVersion>
         <calculationVersion>1.3.0</calculationVersion>


### PR DESCRIPTION
Updated <bahmniCoreVersion> in distro/pom.xml from 2.0.0-SNAPSHOT to 2.0.1-SNAPSHOT
                                                                                                                                                      
  Purpose: Align distro with the bumped bahmni-core version so it pulls the new SNAPSHOT OMOD from Nexus (which contains the Liquibase migration).    
  When distro builds, it will get the correct OMOD version with the migration included, allowing Liquibase to auto-run on Docker container startup. 