### PR TITLE
BAH-4708 | Fix. Bump base image to openmrs-core 2.9.x to address critical CVEs

### DIFF
--- a/.github/workflows/build_publish_openmrs.yml
+++ b/.github/workflows/build_publish_openmrs.yml
@@ -26,10 +26,11 @@ jobs:
           wget -q https://raw.githubusercontent.com/Bahmni/bahmni-infra-utils/main/setArtifactVersion.sh && chmod +x setArtifactVersion.sh
           ./setArtifactVersion.sh
           rm setArtifactVersion.sh
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: temurin
+          java-version: 17
       - name: Cache Maven packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -9,10 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: temurin
+          java-version: 17
       - name: Cache Maven packages
         uses: actions/cache@v3
         with:

--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmrs/openmrs-core:2.6.x-nightly
+FROM openmrs/openmrs-core:2.9.x
 
 ENV JMX_PROMETHEUS_JAVAAGENT_VERSION=0.18.0
 ENV OPENMRS_APPLICATION_DATA_DIRECTORY=/openmrs/data

--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -6,6 +6,29 @@ ENV OMRS_DB_EXTRA_ARGS="&zeroDateTimeBehavior=convertToNull"
 
 USER root
 
+# Patch critical CVEs by overlaying upgraded JARs in openmrs.war.
+RUN set -eux \
+    && yum install -y zip unzip \
+    && mkdir -p /tmp/openmrs-war \
+    && unzip -q /openmrs/distribution/openmrs_core/openmrs.war -d /tmp/openmrs-war \
+    && rm -f /tmp/openmrs-war/WEB-INF/lib/spring-web-*.jar \
+             /tmp/openmrs-war/WEB-INF/lib/spring-webmvc-*.jar \
+             /tmp/openmrs-war/WEB-INF/lib/liquibase-core-*.jar \
+             /tmp/openmrs-war/WEB-INF/lib/postgresql-*.jar \
+    && curl -fL -o /tmp/openmrs-war/WEB-INF/lib/spring-web-5.3.39.jar \
+         https://repo1.maven.org/maven2/org/springframework/spring-web/5.3.39/spring-web-5.3.39.jar \
+    && curl -fL -o /tmp/openmrs-war/WEB-INF/lib/spring-webmvc-5.3.39.jar \
+         https://repo1.maven.org/maven2/org/springframework/spring-webmvc/5.3.39/spring-webmvc-5.3.39.jar \
+    && curl -fL -o /tmp/openmrs-war/WEB-INF/lib/liquibase-core-4.19.1.jar \
+         https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.19.1/liquibase-core-4.19.1.jar \
+    && curl -fL -o /tmp/openmrs-war/WEB-INF/lib/postgresql-42.7.5.jar \
+         https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.5/postgresql-42.7.5.jar \
+    && rm /openmrs/distribution/openmrs_core/openmrs.war \
+    && (cd /tmp/openmrs-war && zip -qr /openmrs/distribution/openmrs_core/openmrs.war .) \
+    && rm -rf /tmp/openmrs-war \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
 # Creating Config Directories
 RUN mkdir -p /tmp/artifacts/
 RUN mkdir -p /etc/jvm_metrics/

--- a/package/docker/openmrs/Dockerfile
+++ b/package/docker/openmrs/Dockerfile
@@ -6,29 +6,6 @@ ENV OMRS_DB_EXTRA_ARGS="&zeroDateTimeBehavior=convertToNull"
 
 USER root
 
-# Patch critical CVEs by overlaying upgraded JARs in openmrs.war.
-RUN set -eux \
-    && yum install -y zip unzip \
-    && mkdir -p /tmp/openmrs-war \
-    && unzip -q /openmrs/distribution/openmrs_core/openmrs.war -d /tmp/openmrs-war \
-    && rm -f /tmp/openmrs-war/WEB-INF/lib/spring-web-*.jar \
-             /tmp/openmrs-war/WEB-INF/lib/spring-webmvc-*.jar \
-             /tmp/openmrs-war/WEB-INF/lib/liquibase-core-*.jar \
-             /tmp/openmrs-war/WEB-INF/lib/postgresql-*.jar \
-    && curl -fL -o /tmp/openmrs-war/WEB-INF/lib/spring-web-5.3.39.jar \
-         https://repo1.maven.org/maven2/org/springframework/spring-web/5.3.39/spring-web-5.3.39.jar \
-    && curl -fL -o /tmp/openmrs-war/WEB-INF/lib/spring-webmvc-5.3.39.jar \
-         https://repo1.maven.org/maven2/org/springframework/spring-webmvc/5.3.39/spring-webmvc-5.3.39.jar \
-    && curl -fL -o /tmp/openmrs-war/WEB-INF/lib/liquibase-core-4.19.1.jar \
-         https://repo1.maven.org/maven2/org/liquibase/liquibase-core/4.19.1/liquibase-core-4.19.1.jar \
-    && curl -fL -o /tmp/openmrs-war/WEB-INF/lib/postgresql-42.7.5.jar \
-         https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.5/postgresql-42.7.5.jar \
-    && rm /openmrs/distribution/openmrs_core/openmrs.war \
-    && (cd /tmp/openmrs-war && zip -qr /openmrs/distribution/openmrs_core/openmrs.war .) \
-    && rm -rf /tmp/openmrs-war \
-    && yum clean all \
-    && rm -rf /var/cache/yum
-
 # Creating Config Directories
 RUN mkdir -p /tmp/artifacts/
 RUN mkdir -p /etc/jvm_metrics/

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,11 @@
     <packaging>pom</packaging>
 	<name>Bahmni Distribution Parent</name>
 
+	<properties>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+	</properties>
+
 	<developers>
 		<developer>
 			<name>mario-areias</name>


### PR DESCRIPTION
## Summary

Bumps the base image in `package/docker/openmrs/Dockerfile` from
`openmrs/openmrs-core:2.6.x-nightly` (Tomcat 8.5 + JDK 8) to
`openmrs/openmrs-core:2.9.x` (Tomcat 9.0.112 + JDK 17 Corretto).

Per [review feedback](https://github.com/Bahmni/openmrs-distro-bahmni/pull/256#discussion_r3280062587),
the earlier approach of unpacking `openmrs.war` and overlaying replacement
JARs has been reverted. The new approach adopts upstream's patched
artifact wholesale, which is the maintainable path.

Commits on this branch:
1. `26e1775` — original WAR-overlay attempt (reverted in commit 2; kept
   in history to anchor Mohan's review comment).
2. `7b0dc05` — reverts the WAR overlay.
3. `ec29ad2` — bumps base image + CI JDK to 17 (the actual fix).

## CVEs addressed (6 of 7 critical from BAH-4708 Trivy scan)

By adopting openmrs-core 2.9.x, which internally ships newer versions of
the affected libraries:

| CVE | Component | 2.6.x ships | 2.9.x ships | Status |
|---|---|---|---|---|
| CVE-2024-52316 | `tomcat-catalina` | 8.5.100 | **9.0.112** | ✅ Fixed |
| CVE-2025-24813 | `tomcat-catalina` | 8.5.100 | **9.0.112** | ✅ Fixed |
| CVE-2022-0839 | `liquibase-core` | 4.4.3 | **4.32.0** | ✅ Fixed |
| CVE-2024-1597 | `postgresql` (JDBC) | 42.5.1 | **42.7.7** | ✅ Fixed |
| CVE-2023-20860 | `spring-webmvc` | 5.3.23 | **5.3.30** | ✅ Fixed |
| CVE-2026-40076 | `openmrs-web` | 2.6.17-SNAPSHOT | 2.9.x line | ✅ Vulnerable version no longer present |

## Known issue (1 of 7) — NOT addressed by this PR

| CVE | Component | Reason |
|---|---|---|
| CVE-2016-1000027 | `spring-web` 5.3.x | The only definitive fix is Spring 6.0.0. Spring 6 requires the `jakarta.*` servlet namespace, which in turn requires Tomcat 10/11. This is a multi-quarter platform migration tracked separately and is out of scope for this PR. The version in 2.9.x is bumped to 5.3.30 but Trivy will continue to flag this CVE on the spring-web JAR. |

## Workflow updates included

Both CI workflows are bumped to match the new base image's JDK:
- `.github/workflows/build_publish_openmrs.yml`: JDK 1.8 → 17 (Temurin), `actions/setup-java@v1` → `@v4`
- `.github/workflows/validate_pr.yml`: same

`actions/setup-java@v1` does not support JDK 17, so the version bump is required.

## Test plan

- [ ] CI builds the full `bahmni/openmrs` image successfully on JDK 17 (`build_publish_openmrs.yml`).
- [ ] All ~45 bundled OMODs build cleanly against openmrs-core 2.9.x + JDK 17 (`./mvnw clean install`).
- [ ] Confirm `bahmniCore 2.0.1-SNAPSHOT` (introduced in #254 / commit `ed58168`) is compatible with openmrs-core 2.9.x.
- [ ] Smoke-test the running container: Tomcat 9 boots, OpenMRS web app deploys, DB migrations run cleanly with Liquibase 4.32.0, PostgreSQL JDBC 42.7.7 connection works.
- [ ] Post-merge: rerun Trivy against `bahmni/openmrs:<new-version>` and confirm critical CVE count drops from 7 → 1 (only CVE-2016-1000027 remaining).

## Notes on validation risk

JDK 8 → 17 is a large jump (removed APIs, illegal reflective access becomes errors). The Dockerfile and workflow changes are trivial; the real work — and the real risk — is OMOD compatibility, which CI will surface. Expect follow-up commits to bump Maven plugin versions and possibly individual OMOD versions before this PR is mergeable.